### PR TITLE
Remove gif as an allowed image filetype

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ def generate_random_id():
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = generate_random_id()
-app.config['ALLOWED_EXTENSIONS'] = set(['png', 'jpg', 'jpeg', 'gif'])
+app.config['ALLOWED_EXTENSIONS'] = set(['png', 'jpg', 'jpeg'])
 
 
 def allowed_file(filename):


### PR DESCRIPTION
Currently, if you upload a .gif, the app with throw a 500 error because the Rekognition API currently does not accepts gifs.

From the [Rekogntion documention](https://docs.aws.amazon.com/rekognition/latest/dg/limits.html):

> Amazon Rekognition supports the PNG and JPEG image formats. That is, the images you provide as input to various API operations, such as DetectLabels and IndexFaces must be in one of the supported formats.

This PR removes ".gif" as an acceptable filetype.  


