### PR TITLE
Feature/accepted file formats

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,7 +242,7 @@ def submit_form():
         return redirect(url_for('index'))
 
     if allowed_file(file):
-        flash("We can't add a mustache to that kind of file. Try a file ending in .png, .jpg, or .gif.")
+        flash("We can't add a mustache to that kind of file. Try a file ending in .png, .jpg or .jpeg")
         return redirect(url_for('index'))
 
     # Mustachify the image

--- a/app.py
+++ b/app.py
@@ -241,7 +241,7 @@ def submit_form():
         flash("Oops, you didn't select a file. Please try again!")
         return redirect(url_for('index'))
 
-    if allowed_file(file):
+    if not allowed_file(file):
         flash("We can't add a mustache to that kind of file. Try a file ending in .png, .jpg or .jpeg")
         return redirect(url_for('index'))
 


### PR DESCRIPTION
Whoops!  I created https://github.com/RagtagOpen/mustachify/pull/24 and it fixed... nothing.  I forgot to test it locally, which, as it turns out,

 would have been a really good idea.

This PR adds a `not` so that we don't send images of the wrong type over to Rekognition.

It also updates the verbiage in the flash message so that we don't mention ".gif".

![stache3](https://user-images.githubusercontent.com/769888/35460909-78a38406-029a-11e8-956d-f0e780c50259.gif)
