### PR TITLE
Fix bug where incorrect object is passed to allowed_file method

### DIFF
--- a/app.py
+++ b/app.py
@@ -241,7 +241,7 @@ def submit_form():
         flash("Oops, you didn't select a file. Please try again!")
         return redirect(url_for('index'))
 
-    if not allowed_file(file):
+    if not allowed_file(file.filename):
         flash("We can't add a mustache to that kind of file. Try a file ending in .png, .jpg or .jpeg")
         return redirect(url_for('index'))
 


### PR DESCRIPTION
Blocking users from uploading a gif, part 3. :/ 

This is part 3 of 3. The first PR removed "gif" from the acceptable formats array, the second PR fixed a missing negation operator, and this third PR ensures that the correct object is passed to the method that determines whether the uploaded file is an acceptable filetype.

I don't know why I didn't notice this on my last PR, but the allowed_file method was receiving the file, instead of just the its filename.  This means that no matter what, the app would reject the uploaded image and refuse to mustachify it.

I should have noticed this earlier.  It was bad QA-ing on my part. :(

![giphy 3](https://user-images.githubusercontent.com/769888/35468681-4b4d9882-02d8-11e8-9d49-e054caef8774.gif)

But now things are working as expected.  If a user uploads a gif, the app politely tells you not to and if a user uploads a png or a jpg, the app accepts the file and mustachifies it.

![stache4](https://user-images.githubusercontent.com/769888/35468711-d80c97be-02d8-11e8-9e57-d9b80fa804f7.gif)
